### PR TITLE
disable buffering of stdio streams

### DIFF
--- a/src/zonetool/main.cpp
+++ b/src/zonetool/main.cpp
@@ -471,6 +471,9 @@ namespace
 
 			try
 			{
+				setvbuf(stdout, NULL, _IONBF, 0);
+				setvbuf(stderr, NULL, _IONBF, 0);
+				
 				if (!component_loader::post_start())
 				{
 					return 0;

--- a/src/zonetool/main.cpp
+++ b/src/zonetool/main.cpp
@@ -471,8 +471,11 @@ namespace
 
 			try
 			{
-				setvbuf(stdout, NULL, _IONBF, 0);
-				setvbuf(stderr, NULL, _IONBF, 0);
+				if(utils::flags::has_flag("unbuffered-io"))
+				{
+					setvbuf(stdout, NULL, _IONBF, 0);
+					setvbuf(stderr, NULL, _IONBF, 0);
+				}
 				
 				if (!component_loader::post_start())
 				{


### PR DESCRIPTION
allows for programs that redirect output (c# process class for example) to capture output/error data directly from zonetool